### PR TITLE
Fix Cadet Wingman Course not displaying completion from eServices

### DIFF
--- a/ConfigConstants.html
+++ b/ConfigConstants.html
@@ -1,6 +1,6 @@
 <script type="text/babel">
 // --- APP METADATA ---
-const APP_VERSION = '1.11.0';  // Semantic version: major.minor.patch
+const APP_VERSION = '1.11.1';  // Semantic version: major.minor.patch
 
 // APP_CONFIG: Receives values from backend via getAppConfig()
 // These are fallback defaults - actual values loaded from Script Properties

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ This project uses [Semantic Versioning](https://semver.org/) (Major.Minor.Patch)
 - **Minor**: New features and enhancements (backward-compatible)
 - **Patch**: Bug fixes and small tweaks
 
-Current version: **1.11.0** (defined in `ConfigConstants.html`)
+Current version: **1.11.1** (defined in `ConfigConstants.html`)
 
 ### Release Process
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CAP Readiness Hub
 
-![Version](https://img.shields.io/badge/version-1.11.0-blue)
+![Version](https://img.shields.io/badge/version-1.11.1-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 A Google Apps Script web application for Civil Air Patrol units to track member readiness, cadet progression, senior member qualifications, and emergency services status.

--- a/ServicesCadetDataService.html
+++ b/ServicesCadetDataService.html
@@ -489,6 +489,21 @@ function createCadetDataService() {
           requirements.characterDevelopment.value = 'Not completed';
         }
       }
+
+      // Check Cadet Wingman Course (Achievement 1 - replaced Character Development)
+      if (requirements.cadetWingmanCourse) {
+        const cadetWingman = isTaskCompleted('329');
+        if (achvData.MoralLDateP && achvData.MoralLDateP !== '01/01/1900') {
+          requirements.cadetWingmanCourse.completed = true;
+          requirements.cadetWingmanCourse.value = `Completed on ${achvData.MoralLDateP}`;
+        } else if (cadetWingman) {
+          requirements.cadetWingmanCourse.completed = true;
+          requirements.cadetWingmanCourse.value = 'Completed';
+        } else {
+          requirements.cadetWingmanCourse.completed = false;
+          requirements.cadetWingmanCourse.value = 'Not completed';
+        }
+      }
     } else {
       // No achievement record yet - still check NEW system (Cadet Interactive Modules) in case cadet completed modules
       // before starting the achievement in the old system
@@ -579,14 +594,14 @@ function createCadetDataService() {
         requirements.characterDevelopment.completed = taskCharacterForum;
         requirements.characterDevelopment.value = taskCharacterForum ? 'Completed' : 'Not completed';
       }
+      if (requirements.cadetWingmanCourse) {
+        const cadetWingman = isTaskCompleted('329');
+        requirements.cadetWingmanCourse.completed = cadetWingman;
+        requirements.cadetWingmanCourse.value = cadetWingman ? 'Completed' : 'Not completed';
+      }
     }
 
     // Add milestone-specific requirements from PL_MemberTaskCredit
-    if (requirements.cadetWingmanCourse) { // Achievement 1 (C/Amn)
-      const cadetWingman = isTaskCompleted('329');
-      requirements.cadetWingmanCourse.completed = cadetWingman;
-      requirements.cadetWingmanCourse.value = cadetWingman ? 'Completed' : 'Not completed';
-    }
     if (requirements.wrightBrothersLeadershipExam) { // Wright Brothers
       const learnToLeadExam = isTaskCompleted('347');
       requirements.wrightBrothersLeadershipExam.completed = learnToLeadExam;


### PR DESCRIPTION
The Cadet Wingman Course check for Achievement 1 (C/Amn) only consulted PL_MemberTaskCredit (TaskID 329) and never checked the CadetAchv table's MoralLDateP field, which is where eServices records the completion. This caused the requirement to show "Not completed" even when it was entered in eServices.

Moved the cadetWingmanCourse check into both the achvData and fallback branches of processManualRequirements(), matching the dual-system pattern used by all other manual requirements (Active Participation, Cadet Oath, Character Development, etc...). When achvData exists, MoralLDateP is checked first (with date display), falling back to TaskID 329. When no achvData record exists, only TaskID 329 is checked.